### PR TITLE
feat(404, web-linking): nested web linking, clean URLs, 404 page 

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -75,7 +75,7 @@
       "node"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!react-native|@react-native|react-native-vector-icons)"
+      "node_modules/(?!react-native|@react-native|react-native-vector-icons|@react-navigation)"
     ]
   },
   "browserslist": {

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -118,7 +118,7 @@ const TopTabNavigator = () => {
 
   // Dark mode theming items
   const isDarkMode = useColorScheme() === 'dark';
-  const accentColor = isDarkMode ? Colors.ligher : Colors.darker;
+  const accentColor = isDarkMode ? Colors.lighter : Colors.darker;
   const primaryColor = isDarkMode ? Colors.darker : Colors.lighter;
   const backgroundStyle = {backgroundColor: primaryColor, flex: 1};
 
@@ -129,7 +129,7 @@ const TopTabNavigator = () => {
         style={[
           styles.sectionTitle,
           {
-            color: isDarkMode ? Colors.white : Colors.black,
+            color: accentColor,
           },
         ]}>
         If you see a rocket, react-native-vector-icons is working!
@@ -192,6 +192,7 @@ const styles = StyleSheet.create({
     alignContent: 'center',
     justifyContent: 'center',
     alignItems: 'center',
+    paddingHorizontal: 24,
   },
   sectionContainer: {
     marginTop: 32,

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -12,6 +12,7 @@ import appJson from './app.json';
 import React from 'react';
 import {
   Button,
+  Dimensions,
   ScrollView,
   StyleSheet,
   Text,
@@ -30,11 +31,12 @@ import {
   SafeAreaProvider,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
-import {useLinkTo} from '@react-navigation/native';
+import {useLinkTo, useNavigation} from '@react-navigation/native';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
 import {NavigationContainer} from '@react-navigation/native';
+import {createStackNavigator} from '@react-navigation/stack';
 
 // *****************************************************************************************************
 // This pasted directly in from this file upstream
@@ -108,6 +110,75 @@ const App = () => {
 
 // *****************************************************************************************************
 // The rest of the file is to set up a react-navigation and react-native-vector-icons demonstration:
+const Stack = createStackNavigator();
+const StackNavigator = () => {
+  const linkTo = useLinkTo();
+  const navigation = useNavigation();
+
+  // Dark mode theming items
+  const isDarkMode = useColorScheme() === 'dark';
+  const primaryColor = isDarkMode ? Colors.darker : Colors.lighter;
+  const accentColor = isDarkMode ? Colors.lighter : Colors.darker;
+  const backgroundStyle = {backgroundColor: primaryColor, flex: 1};
+
+  const NotFound = () => {
+    return (
+      <View style={[backgroundStyle, styles.detailsContainer]}>
+        <Text
+          style={[
+            styles.sectionTitle,
+            {
+              color: accentColor,
+            },
+          ]}>
+          Oh no! This page does not exist.
+        </Text>
+        <View style={styles.spacer} />
+        <Text
+          style={[
+            styles.sectionTitle,
+            {
+              color: accentColor,
+            },
+          ]}>
+          On Android and web, the back button will take you back. On iOS you may
+          swipe to go back.
+        </Text>
+        {navigation.canGoBack() && (
+          <>
+            <View style={styles.spacer} />
+            <Button
+              title="navigation.goBack()"
+              onPress={() => {
+                navigation.goBack();
+              }}
+            />
+          </>
+        )}
+        <View style={styles.spacer} />
+        <Button title="Go to '/'" onPress={() => linkTo('/')} />
+      </View>
+    );
+  };
+
+  return (
+    <Stack.Navigator
+      initialRouteName="App"
+      screenOptions={{
+        // TODO - investigate why setting width/height is needed on web but not mobile.
+        // Without it, the card gets height of content in largest tab and overflows with no scroll?
+        cardStyle: {
+          width: Dimensions.get('window').width,
+          height: Dimensions.get('window').height,
+        },
+        headerShown: false,
+      }}>
+      <Stack.Screen component={TopTabNavigator} name="App" />
+      <Stack.Screen component={NotFound} name="NotFound" />
+    </Stack.Navigator>
+  );
+};
+
 const Tab = createMaterialTopTabNavigator();
 const TopTabNavigator = () => {
   // Used for status bar layout in react-navigation
@@ -140,6 +211,11 @@ const TopTabNavigator = () => {
     return (
       <View style={[backgroundStyle, styles.detailsContainer]}>
         <Button title="Link to Details" onPress={() => linkTo('/details')} />
+        <View style={styles.spacer} />
+        <Button
+          title="Link to a non-existent route"
+          onPress={() => linkTo('/nonexistent/route')}
+        />
       </View>
     );
   };
@@ -170,9 +246,18 @@ const TabbedApp = () => {
           prefixes: ['plaut-ro.github.io/luna', 'localhost'],
           config: {
             screens: {
-              Details: 'details',
-              Linking: 'linking',
-              Home: '*', // Fall back to if no routes match
+              NotFound: '*', // Match any unknown route with our NotFound screen
+              App: {
+                path: '', // omit '/App' in the browser URL bar
+                // @ts-ignore - TODO screens in nested nav do not seem to be typed correctly upstream?
+                screens: {
+                  Home: {
+                    path: '', // omit '/Home' in the browser URL bar, this is our '/' URL (vs '/App/Home')
+                  },
+                  Details: 'details', // because of '' omissions above, this is just '/details', not '/App/details'
+                  Linking: 'linking', // shows up at '/linking'
+                },
+              },
             },
           },
         }}
@@ -180,7 +265,7 @@ const TabbedApp = () => {
           formatter: (options, route) =>
             `${appJson.displayName} - ${options?.title ?? route?.name}`,
         }}>
-        <TopTabNavigator />
+        <StackNavigator />
       </NavigationContainer>
     </SafeAreaProvider>
   );
@@ -209,6 +294,9 @@ const styles = StyleSheet.create({
   },
   highlight: {
     fontWeight: '700',
+  },
+  spacer: {
+    height: 20,
   },
 });
 


### PR DESCRIPTION

Who knew web-compatible navigation would be subtle? I did not.

I need to handle these things though, and none were handled with this template or my previous knowledge:
- deep links
- 404 pages
- web compatible routing (that is: URL <--> route name correspondence) with nested navigators

So after reading the react-navigation docs about deep linking and playing with it here I got it all working:
https://reactnavigation.org/docs/configuring-links/

Features used:
- nested linking config (but react-navigation types are busted there? I had to ts-ignore. Haven't logged it yet)
https://reactnavigation.org/docs/configuring-links/#handling-nested-navigators

- URL 'cleaning' on our default first screen path 
https://reactnavigation.org/docs/configuring-links/#omitting-a-screen-from-path

- 404 / catch all routing:
https://reactnavigation.org/docs/configuring-links/#handling-unmatched-routes-or-404

If you like this and merge it, I think it handles all of the navigation cases that I've come across as I build and QA the web part of my work projects. Took a while to get there!
