### PR TITLE
fix(web): force no zoom on web

### DIFF
--- a/template/public/index.html
+++ b/template/public/index.html
@@ -7,19 +7,20 @@
     <title>React Native Web Example</title>
 
     <style>
-      /* These styles make the body full-height */
       html,
-      body {
-        height: 100%;
-      }
-      /* These styles disable body scrolling if you are using <ScrollView> */
-      body {
-        overflow: hidden;
-      }
-      /* These styles make the root element full-height */
+      body,
       #root {
+        /* These styles make the root element exactly full-size */
+        flex: 1;
         display: flex;
+        max-height: 100vh;
         height: 100%;
+        width: 100%;
+
+        /* These styles disable body scrolling if you are using <ScrollView> */
+        overflow: hidden;
+        -ms-overflow-style: none;
+        scrollbar-width: none;
       }
     </style>
   </head>


### PR DESCRIPTION

Hey @criszz77 - this is more of a question, I am using this on my work projects because otherwise it's possible for the screen state on mobile (where people touch and drag etc) to become a bit wierd.

I don't like it though, and I think I'm wondering whether to investigate the underlying cause more (it's possible for navigation drawers to slide off screen on web as their method of hiding I think - meaning when a user zooms out via mobile pinch gesture they can see the nav bar off to the side)

The question is: how much is disabling zoom a known thing on web? Is it as big a deal as I think it is? (that is: I feel like it damages accessibility because if an element is hard to read a user may no longer just zoom in to read it I think...)